### PR TITLE
Bug fix

### DIFF
--- a/mq_client.go
+++ b/mq_client.go
@@ -335,7 +335,7 @@ func (m *MqClient) updateTopicRouteInfoFromNameServerKernel(topic string, isDefa
 		topicRouteData, err = m.getTopicRouteInfoFromNameServer(topic, 3000*1000)
 	}
 
-	if !topicRouteDataIsNil(topicRouteData) {
+	if topicRouteData != nil && !topicRouteDataIsNil(topicRouteData) {
 		old := m.topicRouteTable[topic]
 		changed := sliceCompare(old, topicRouteData)
 

--- a/producer.go
+++ b/producer.go
@@ -281,7 +281,7 @@ func (d *DefaultProducer) sendKernel(msg *Message, mq *MessageQueue, communicati
 		}
 
 		if d.hasCheckForbiddenHook() {
-			fmt.Println(brokerAddr)
+			fmt.Fprintf(os.Stderr, brokerAddr)
 		}
 		if d.hasSendMessageHook() {
 		}
@@ -398,9 +398,9 @@ func (d *DefaultProducer) sendMessage(addr string, brokerName string, msg *Messa
 
 func (d *DefaultProducer) sendMessageSync(addr string, brokerName string, msg *Message, timeoutMillis int64, remotingCommand *RemotingCommand) (sendResult *SendResult, err error) {
 	var response *RemotingCommand
-	fmt.Println("msg:", msg.Topic, msg.Flag, string(msg.Body), msg.Properties)
+	fmt.Fprintln(os.Stderr, "msg:", msg.Topic, msg.Flag, string(msg.Body), msg.Properties)
 	if response, err = d.remotingClient.invokeSync(addr, remotingCommand, timeoutMillis); err != nil {
-		fmt.Println("sendMessageSync err", err)
+		fmt.Fprintln(os.Stderr, "sendMessageSync err", err)
 	}
 	return d.processSendResponse(brokerName, msg, response)
 }
@@ -425,7 +425,7 @@ func (d *DefaultProducer) sendMessageAsync(addr string, brokerName string, msg *
 		sendCallback()
 		if responseCommand != nil {
 			if sendResult, err = d.processSendResponse(brokerName, msg, responseCommand); sendResult == nil || err != nil {
-				fmt.Println("sendResult can't be null, error ", err)
+				fmt.Fprintln(os.Stderr, "sendResult can't be null, error ", err)
 				producer.updateFaultItem(brokerName, time.Now().Unix()-responseFuture.beginTimestamp, true)
 				return
 			} else {
@@ -444,6 +444,11 @@ func (d *DefaultProducer) sendMessageAsync(addr string, brokerName string, msg *
 
 func (d *DefaultProducer) processSendResponse(brokerName string, msg *Message, response *RemotingCommand) (sendResult *SendResult, err error) {
 	var sendStatus int
+
+	if response == nil {
+		err = errors.New("response in processSendResponse is nil!")
+		return
+	}
 	switch response.Code {
 	// TODO add log
 	case FlushDiskTimeout:


### PR DESCRIPTION
Fix the problem of : while broke service was stopped,go_rocket_mq client would exit with panic .
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0xa620f9]

goroutine 21 [running]:
xxx/vendor/github.com/sevenNt/go_rocket_mq.(*MqClient).updateTopicRouteInfoFromNameServerKernel(0xc4201ba480, 0xc1fda6, 0x6, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
	xxx/vendor/github.com/sevenNt/go_rocket_mq/mq_client.go:340 +0x139
xxx/vendor/github.com/sevenNt/go_rocket_mq.(*MqClient).updateTopicRouteInfoFromNameServer(0xc4201ba480)
	xxx/vendor/github.com/sevenNt/go_rocket_mq/mq_client.go:287 +0x4cd
xxx/vendor/github.com/sevenNt/go_rocket_mq.(*MqClient).startScheduledTask.func1(0xc4201ba480)
	xxx/vendor/github.com/sevenNt/go_rocket_mq/mq_client.go:516 +0x69
created by xxx/vendor/github.com/sevenNt/go_rocket_mq.(*MqClient).startScheduledTask
	xxx/vendor/github.com/sevenNt/go_rocket_mq/mq_client.go:519 +0x43
```